### PR TITLE
Cloudbuild Repositories

### DIFF
--- a/modules/gcp/components/cloudbuild_github/main.tf
+++ b/modules/gcp/components/cloudbuild_github/main.tf
@@ -18,3 +18,13 @@ module "my_github_cloudbuild_connection" {
   region              = var.region
   source              = "../cloudbuild_github_connection"
 }
+
+module "repo_and_triggers" {
+  for_each            = var.repositories
+  project_id          = var.project_id
+  region              = var.region
+  source              = "../cloudbuild_repo_and_triggers"
+  parent_connection   = module.my_github_cloudbuild_connection.github_connection_id
+  repo_name           = each.key
+  remote_uri          = each.value["remote_uri"]
+}

--- a/modules/gcp/components/cloudbuild_github/variables.tf
+++ b/modules/gcp/components/cloudbuild_github/variables.tf
@@ -50,8 +50,7 @@ variable "region" {
 }
 
 variable "repositories" {
-  default  = null
-  nullable = true
+  default  = {}
   type = map(object({
     remote_uri     = string
     build_triggers = optional(map(object({

--- a/modules/gcp/components/cloudbuild_repo_and_triggers/main.tf
+++ b/modules/gcp/components/cloudbuild_repo_and_triggers/main.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.17.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 5.17.0"
+    }
+  }
+}
+
+module "repo" {
+  name              = var.repo_name
+  parent_connection = var.parent_connection
+  project_id        = var.project_id
+  region            = var.region
+  remote_uri        = var.remote_uri
+  source            = "../../common/cloudbuild_repository"
+}

--- a/modules/gcp/components/cloudbuild_repo_and_triggers/variables.tf
+++ b/modules/gcp/components/cloudbuild_repo_and_triggers/variables.tf
@@ -1,0 +1,41 @@
+/* 
+   Repository name
+ */
+variable "repo_name" {
+  description = "Name of the repository"
+  type = string
+}
+
+/* 
+   Parent connection. This comes from the resource ID from the
+   google_cloudbuildv2_connection resource. i.e.
+   google_cloudbuildv2_connection.[NAME].id
+ */
+variable "parent_connection" {
+  description = "Parent connection. This comes from the resource ID from the google_cloudbuildv2_connection"
+  type = string
+}
+
+/* 
+   Project ID
+ */
+variable "project_id" {
+  description = "Project ID"
+  type = string
+}
+
+/* 
+   Region to create the Cloud RUn service in
+ */
+variable "region" {
+  description = "Region to create the Cloud Run service in"
+  type        = string
+}
+
+/* 
+   Remote URI for the Github repository, i.e. https://github.com/ORG/REPO.git
+ */
+variable "remote_uri" {
+  description = "Remote URI for the Github repository, i.e. https://github.com/ORG/REPO.git"
+  type        = string
+}


### PR DESCRIPTION
Adds in cloudbuild repositories as an option to the cloudbuild_github module that will create a repository for each of the repositories defined